### PR TITLE
Remove onSaveInstanceState's EMPTY_STATE check and use class extensio…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=2.7.0
+VERSION_NAME=2.7.1-FORK
 GROUP=se.emilsjolander
 
 POM_DESCRIPTION=A small android library that makes it easy to make lists with section headers that stick to the top until a new section header comes along.

--- a/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
+++ b/library/src/se/emilsjolander/stickylistheaders/StickyListHeadersListView.java
@@ -8,6 +8,7 @@ import android.database.DataSetObserver;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -1093,17 +1094,14 @@ public class StickyListHeadersListView extends FrameLayout {
 
     @Override
     public Parcelable onSaveInstanceState() {
-        Parcelable superState = super.onSaveInstanceState();
-        if (superState != BaseSavedState.EMPTY_STATE) {
-          throw new IllegalStateException("Handling non empty state of parent class is not implemented");
-        }
-        return mList.onSaveInstanceState();
+        return new SavedState(super.onSaveInstanceState(), mList.onSaveInstanceState());
     }
 
     @Override
     public void onRestoreInstanceState(Parcelable state) {
-        super.onRestoreInstanceState(BaseSavedState.EMPTY_STATE);
-        mList.onRestoreInstanceState(state);
+        SavedState ss = (SavedState) state;
+        super.onRestoreInstanceState(ss.getSuperState());
+        mList.onRestoreInstanceState(ss.wrappedState);
     }
 
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
@@ -1126,5 +1124,42 @@ public class StickyListHeadersListView extends FrameLayout {
 
     public boolean isStackFromBottom() {
     	return mList.isStackFromBottom();
+    }
+
+    static class SavedState extends BaseSavedState {
+        private Parcelable wrappedState;
+
+        /**
+         * Constructor called from {@link StickyListHeadersListView#onSaveInstanceState()}
+         */
+        SavedState(Parcelable superState, Parcelable wrappedState) {
+            super(superState);
+            this.wrappedState = wrappedState;
+        }
+
+        /**
+         * Constructor called from {@link #CREATOR}
+         */
+        private SavedState(Parcel in) {
+            super(in);
+            wrappedState = in.readParcelable(null);
+        }
+
+        @Override
+        public void writeToParcel(Parcel out, int flags) {
+            super.writeToParcel(out, flags);
+            out.writeParcelable(wrappedState, flags);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR
+                = new Parcelable.Creator<SavedState>() {
+            public SavedState createFromParcel(Parcel in) {
+                return new SavedState(in);
+            }
+
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        };
     }
 }


### PR DESCRIPTION
…n of BaseSavedState for saving and restoring state

Fix for issue: https://github.com/emilsjolander/StickyListHeaders/issues/477

We are using mtotschnig's approach for the bug fix. 
However, his mtotschnig's version of repo had 22 commits at the time of this PR but we only want to keep the bug fix PR's
https://github.com/mtotschnig/StickyListHeaders



